### PR TITLE
Fix PKGBUILD (lib32-mesa-git)

### DIFF
--- a/mesa-git/PKGBUILD
+++ b/mesa-git/PKGBUILD
@@ -322,8 +322,8 @@ package_lib32-mesa-git() {
            'lib32-libxshmfence' "lib32-llvm-libs-git=$LLVM32_VERSION" 'lib32-vulkan-icd-loader'
            'lib32-wayland' 'lib32-lm_sensors' 'lib32-libglvnd' 'mesa-git')
   optdepends=('opengl-man-pages: for the OpenGL API man pages')
-  provides=('lib32-mesa' 'lib32-mesa-vdpau' 'lib32-mesa-libgl' 'lib32-opengl-driver')
-  conflicts=('lib32-mesa' 'lib32-mesa-vdpau' 'lib32-mesa-libgl')
+  provides=('lib32-mesa' 'lib32-mesa-vdpau' 'lib32-mesa-libgl' 'lib32-opengl-driver' 'lib32-libva-mesa-driver')
+  conflicts=('lib32-mesa' 'lib32-mesa-vdpau' 'lib32-mesa-libgl' 'lib32-libva-mesa-driver')
 
   # lib32-libva-mesa-driver
   _install_32 fakeinstall_32/usr/lib32/dri/*_drv_video.so


### PR DESCRIPTION
lib32-mesa-git is missing `lib32-libva-mesa-driver` in Provides and Conflicts, causing installation to fail because of conflicting files